### PR TITLE
Bump dependencies

### DIFF
--- a/hasql-generic.cabal
+++ b/hasql-generic.cabal
@@ -24,10 +24,10 @@ library
                      , containers >= 0.5 && < 0.7
                      , contravariant >= 1.4 && < 1.6
                      , generics-sop >= 0.2 && < 0.5
-                     , hasql >= 1.3 && < 1.4
+                     , hasql >= 1.3 && <= 1.5.0.5
                      , postgresql-binary >= 0.9 && < 0.13
                      , scientific >= 0.3 && < 0.4
-                     , text >= 1.2 && < 1.3
+                     , text >= 1.2 && < 1.3 || >= 2.0 && < 2.1
                      , time >= 1.6 && < 1.9
                      , uuid >= 1.3 && < 1.4
                      , vector >= 0.11 && < 0.13


### PR DESCRIPTION
Tested on GHC 9.4.4, the dependencies could safely be bumped to the specified versions.